### PR TITLE
Replace GNU cp -u

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -355,9 +355,9 @@ cd ${EOSIO_CONTEXT_DIR__}
 mkdir -p ${BUILD_DIR}
 mkdir -p ${BUILD_DIR}/daemon/data-dir/wallet
 
-cp ${EOSIO_SOURCE_DIR}/programs/snapshot/genesis.json \
+cp -p ${EOSIO_SOURCE_DIR}/programs/snapshot/genesis.json \
     ${BUILD_DIR}/daemon/data-dir/genesis.json
-cp ${EOSIO_CONTEXT_DIR__}/resources/config.ini \
+cp -p ${EOSIO_CONTEXT_DIR__}/resources/config.ini \
     ${BUILD_DIR}/daemon/data-dir/config.ini
 
 


### PR DESCRIPTION
Replace GNU cp -u, which does not exist on OS X, with cp -p which is BSD and GNU compatible