### PR TITLE
Check if we actually have source code to compile.

### DIFF
--- a/pyteos/core/teos.py
+++ b/pyteos/core/teos.py
@@ -169,6 +169,8 @@ def WAST(
             raise errors.Error(str(e))
 
     if not compile_only:
+        if not objectFileList:
+            raise errors.Error('No source code in contract directory.')
         command_line = [ 
             config.getEOSIO_WASM_LLVM_LINK(),
             "-only-needed", 

--- a/pyteos/shell/setup.py
+++ b/pyteos/shell/setup.py
@@ -14,7 +14,7 @@ EOSIO_CONTRACT_DIR = "build/contracts/"
 __nodeos_address = None
 
 
-is_print_command_line = False
+is_print_command_line = True
 is_print_request = False
 is_print_response = False
 


### PR DESCRIPTION
It is possible to have a situation where contract directory appears to have
source code, but actually has nothing to compile.  Proceeding gives a
cryptic error message.

Closes #73 
