### PR TITLE
Adding the required command line option -contract for abigen eosio.cdt v.1.3.2

### DIFF
--- a/eosfactory/core/teos.py
+++ b/eosfactory/core/teos.py
@@ -67,7 +67,7 @@ def ABI(contract_dir_hint=None, code_name=None, include_dir=None):
         for file in srcs:
             if not os.path.splitext(file)[1].lower() in extensions:
                 continue
-            command_line.append(file)
+            command_line.extend(["-contract=" + os.path.splitext(os.path.basename(file))[0], file])
         
         try:
             process(command_line)


### PR DESCRIPTION
This request is bug fix that was seen when trying to generate an abi file during the build contract. In the current behavior, I received an error about the absence of the required option "-contract" for the name of the contract. In the new behavior, I added this option and as its argument I specify the name of the source file without an extension.

My environment:
eosio v. 1.4.3
eosio.cdt v. 1.3.2
eosfactory v. 2.2

With best regards.