### PR TITLE
CDT inside docker + new default eos branch for base image

### DIFF
--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -91,6 +91,9 @@ RUN /opt/eosfactory/tests/integration/expect_script.sh
 RUN sed -i 's/mesg n || true/tty -s \&\& mesg n || true/g' /root/.profile
 RUN chmod +x ./tests/unittest.sh
 
+RUN wget https://github.com/eosio/eosio.cdt/releases/download/v1.4.1/eosio.cdt-1.4.1.x86_64.deb
+RUN apt install ./eosio.cdt-1.4.1.x86_64.deb && rm ./eosio.cdt-1.4.1.x86_64.deb
+
 WORKDIR /opt/eosfactory/tests/
 
 # bash loads .profile by default

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -75,6 +75,12 @@ RUN set -ex; \
 	rm -f get-pip.py
 
 RUN python -m pip install termcolor
+############## EOS CDT #############################################################################################
+
+RUN wget https://github.com/eosio/eosio.cdt/releases/download/v1.4.1/eosio.cdt-1.4.1.x86_64.deb && \
+    apt install ./eosio.cdt-1.4.1.x86_64.deb \
+    && rm ./eosio.cdt-1.4.1.x86_64.deb
+
 ############## EOS FACTORY #############################################################################################
 
 ARG eosfactory_branch=master
@@ -90,9 +96,6 @@ RUN /opt/eosfactory/tests/integration/expect_script.sh
 # https://superuser.com/a/1253889/59009
 RUN sed -i 's/mesg n || true/tty -s \&\& mesg n || true/g' /root/.profile
 RUN chmod +x ./tests/unittest.sh
-
-RUN wget https://github.com/eosio/eosio.cdt/releases/download/v1.4.1/eosio.cdt-1.4.1.x86_64.deb
-RUN apt install ./eosio.cdt-1.4.1.x86_64.deb && rm ./eosio.cdt-1.4.1.x86_64.deb
 
 WORKDIR /opt/eosfactory/tests/
 

--- a/tests/integration/eosio-base.Dockerfile
+++ b/tests/integration/eosio-base.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 
 ##############     EOS     #############################################################################################
 
-ARG eos_branch=v1.3.1
+ARG eos_branch=v1.5.0
 ARG eos_symbol=SYS
  
 RUN git clone -b $eos_branch https://github.com/EOSIO/eos.git --recursive /opt/eos

--- a/tests/integration/expect_script.sh
+++ b/tests/integration/expect_script.sh
@@ -3,6 +3,4 @@
 spawn ./install.sh
 expect -exact "Input an existing directory path:\r"
 send -- "/opt/eos\r"
-expect -exact "Input an existing directory path:\r"
-send -- "/opt/workspace\r"
 expect eof


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - CDT is installed inside a docker container used for tests 
  - new default eos branch: `v1.5.0`
  - install.sh do not ask for workspace anymore -> expect script modified