### PR TITLE
Fix unrecognised option 'max-implicit-request' error on startup

### DIFF
--- a/localnode/config.ini
+++ b/localnode/config.ini
@@ -218,9 +218,6 @@ network-version-match = 0
 # number of blocks to retrieve in a chunk from any individual peer during synchronization (eosio::net_plugin)
 sync-fetch-span = 100
 
-# maximum sizes of transaction or block messages that are sent without first sending a notice (eosio::net_plugin)
-max-implicit-request = 1500
-
 # Enable expirimental socket read watermark optimization (eosio::net_plugin)
 use-socket-read-watermark = 0
 


### PR DESCRIPTION
This option has been removed in EOS 1.6.0. See https://github.com/EOSIO/eos/pull/6464.


