### PR TITLE
Install under user directory instead of sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,7 @@ Installing the 'eosfactory' package locally with the Python pip system...
 # It is essentioal that the package is installed as a symlink, with 
 # the flag '-e'
 ###############################################################################
-sudo  -H python3 -m pip install -e .
+python3 -m pip install --user -e .
 
 printf "%s\n" "
 Configuring the eosfactory installation...


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
No longer installs eosfactory under super user


* **What is the current behavior?** (You can also link to an open issue here)
You need to run the script and subsequent `python3` commands with `sudo` which is annoying.


* **What is the new behavior (if this is a feature change)?**
You don't need to use `sudo` anymore.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Perhaps remove `sudo` from some of their scripts/code.


* **Other information**:
Clear out any existing `eosfactory.egg-info`, `localnode/blocks`, `localnode/state` files using sudo before running the install script with the changes.

