### PR TITLE
Assigns created accounts in the hello world test templates to actual variables

### DIFF
--- a/templates/contracts/01_hello_world/tests/test1.py
+++ b/templates/contracts/01_hello_world/tests/test1.py
@@ -5,17 +5,18 @@ verbosity([Verbosity.INFO, Verbosity.OUT, Verbosity.DEBUG])
 
 CONTRACT_WORKSPACE = sys.path[0] + "/../"
 
+
 def test():
     SCENARIO('''
     Execute simple actions.
     ''')
     reset()
-    create_master_account("master")
+    master = create_master_account("master")
 
     COMMENT('''
     Build and deploy the contract:
     ''')
-    create_account("host", master)
+    host = create_account("host", master)
     contract = Contract(host, CONTRACT_WORKSPACE)
     contract.build(force=False)
     contract.deploy()
@@ -23,21 +24,21 @@ def test():
     COMMENT('''
     Create test accounts:
     ''')
-    create_account("alice", master)
-    create_account("carol", master)
+    alice = create_account("alice", master)
+    carol = create_account("carol", master)
 
     COMMENT('''
     Test an action for Alice:
     ''')
     host.push_action(
-        "hi", {"user":alice}, permission=(alice, Permission.ACTIVE))
+        "hi", {"user": alice}, permission=(alice, Permission.ACTIVE))
     assert("alice" in DEBUG())
 
     COMMENT('''
     Test an action for Carol:
     ''')
     host.push_action(
-        "hi", {"user":carol}, permission=(carol, Permission.ACTIVE))
+        "hi", {"user": carol}, permission=(carol, Permission.ACTIVE))
     assert("carol" in DEBUG())
 
     stop()

--- a/templates/contracts/01_hello_world/tests/unittest1.py
+++ b/templates/contracts/01_hello_world/tests/unittest1.py
@@ -1,15 +1,16 @@
-import unittest, sys
+import unittest
+import sys
 from eosfactory.eosf import *
 
 verbosity([Verbosity.INFO, Verbosity.OUT])
 
 CONTRACT_WORKSPACE = sys.path[0] + "/../"
 
+
 class Test(unittest.TestCase):
 
     def run(self, result=None):
         super().run(result)
-
 
     @classmethod
     def setUpClass(cls):
@@ -17,52 +18,49 @@ class Test(unittest.TestCase):
         Execute simple actions.
         ''')
         reset()
-        create_master_account("master")
+
+        cls.master = create_master_account("master")
 
         COMMENT('''
         Build and deploy the contract:
         ''')
-        create_account("host", master)
-        contract = Contract(host, CONTRACT_WORKSPACE)
+        cls.host = create_account("host", cls.master)
+        contract = Contract(cls.host, CONTRACT_WORKSPACE)
         contract.build(force=False)
         contract.deploy()
 
         COMMENT('''
         Create test accounts:
         ''')
-        create_account("alice", master)
-        create_account("carol", master)
-        create_account("bob", master)
-
+        cls.alice = create_account("alice", cls.master)
+        cls.carol = create_account("carol", cls.master)
+        cls.bob = create_account("bob", cls.master)
 
     def setUp(self):
         pass
-
 
     def test_01(self):
         COMMENT('''
         Test an action for Alice:
         ''')
-        host.push_action(
-            "hi", {"user":alice}, permission=(alice, Permission.ACTIVE))
+        self.host.push_action(
+            "hi", {"user": self.alice}, permission=(self.alice, Permission.ACTIVE))
 
         COMMENT('''
         Test an action for Carol:
         ''')
-        host.push_action(
-            "hi", {"user":carol}, permission=(carol, Permission.ACTIVE))
+        self.host.push_action(
+            "hi", {"user": self.carol}, permission=(self.carol, Permission.ACTIVE))
 
         COMMENT('''
         WARNING: This action should fail due to authority mismatch!
         ''')
         with self.assertRaises(MissingRequiredAuthorityError):
-            host.push_action(
-                "hi", {"user":carol}, permission=(bob, Permission.ACTIVE))
-
+            self.host.push_action(
+                "hi", {"user": self.carol}, permission=(self.bob, Permission.ACTIVE))
 
     def tearDown(self):
         pass
-
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Assigns created accounts in the hello world test templates to actual variables.


* **What is the current behavior?** (You can also link to an open issue here)
Created accounts are injected as global variables


* **What is the new behavior (if this is a feature change)?**
variables are assigned to their respected `self` fields


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Users will need to prefix self or cls before their variables


* **Other information**:
Was this a design decision to make the accounts global variables? I'm using pylint and its complaining about undefined variables... assigning them to class variables seems to make everything work the same and also gives the benefit of code navigation.

