### PR TITLE
Gather inline actions console output

### DIFF
--- a/eosfactory/core/cleos.py
+++ b/eosfactory/core/cleos.py
@@ -707,11 +707,9 @@ class PushAction(Cleos):
         self.console = ""
         self.act = ""
         if not dont_broadcast:
-            for trace in self.json["processed"]["action_traces"]:
-                if trace["console"]:
-                    if self.console:
-                        self.console += "\n"
-                    self.console += trace["console"]
+            
+            for act in self.json["processed"]["action_traces"]:
+                self.console += gather_console_output(act)
 
             for trace in self.json["processed"]["action_traces"]:
                 if trace["act"]["data"]:
@@ -724,3 +722,13 @@ class PushAction(Cleos):
                                                         trace["act"]["data"])
         self.printself()
 
+def gather_console_output(act, padding=""):
+    PADDING = "  "
+    console = ""
+    if len(act["console"]) > 0:
+        console += padding + act["act"]["account"] + "@" + act["act"]["name"] + ":\n"
+        console += padding + act["console"].replace("\n", "\n" + padding) + "\n"
+
+    for inline in act["inline_traces"]:
+        console += gather_console_output(inline, padding + PADDING)
+    return (console + "\n").strip()

--- a/eosfactory/core/cleos.py
+++ b/eosfactory/core/cleos.py
@@ -731,4 +731,4 @@ def gather_console_output(act, padding=""):
 
     for inline in act["inline_traces"]:
         console += gather_console_output(inline, padding + PADDING)
-    return (console + "\n").strip()
+    return (console + "\n").rstrip()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Console is only gathered from top-level actions in a transaction


* **What is the new behavior (if this is a feature change)?**
Collect console output from all actions in a transaction and all inline actions recursively. 
Every inline action has additional padding of "  " depending on its depth in the transaction.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking changes

New console output example:

```
eosio_token@transfer:
INFO from: user @ 11:16:1 eosio_token.cpp[97](transfer)
INFO to: mycontract @ 11:16:1 eosio_token.cpp[98](transfer)
INFO quantity: 20.0000 EOS @ 11:16:1 eosio_token.cpp[99](transfer)

  mycontract@inlineactiontest:
  deposited 20.0000 EOS @ user

    mycontract@inlineactiontest2:
    even deeper inline trace output
```
