### PR TITLE
Tests take a long time to launch (node probing delays)

### DIFF
--- a/eosfactory/core/teos.py
+++ b/eosfactory/core/teos.py
@@ -751,10 +751,10 @@ def node_probe():
     count1 = count - 7
     num = 5
     block_num = None
-    time.sleep(5)
+    time.sleep(0.5)
 
     while True:
-        time.sleep(1)
+        time.sleep(0.2)
         count = count - 1
         if count > count1:
             print(".", end="", flush=True)


### PR DESCRIPTION
* **What is the current behavior?** (You can also link to an open issue here)
It takes around 15 seconds  for the tests to begin.

* **What is the new behavior (if this is a feature change)?**
It takes less than 5 seconds for the tests to begin.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
(using nodeos v1.7.3)
After some update eosfactory became insufferably slow to launch.
After doing some research on why that might be, I've found that node probing was taking way too long.
I've played around with those 2 numbers and picked them by the best results for my case.
Now the test begins on block 8 (which is ~4.5 seconds) instead of block 30.

I have to say that I'm not exactly sure why these numbers were chosen initially and how this will affect eosfactory running on other devices. 
I only have my macbook to test it and exact change should be tested before publishing.
I just want to bring this problem to light: waiting 15 seconds to start the test is unacceptable.

