### PR TITLE
Bugfix on get_pid when p.info["name"] is None

### DIFF
--- a/eosfactory/core/teos.py
+++ b/eosfactory/core/teos.py
@@ -542,7 +542,7 @@ def get_pid(name=None):
 
     pids = []
     processes = [p.info for p in psutil.process_iter(attrs=["pid", "name"]) \
-                                        if name in p.info["name"]]
+                                        if p.info["name"] and name in p.info["name"]]
     for process in processes:
         pids.append(process["pid"])
 

--- a/eosfactory/core/teos.py
+++ b/eosfactory/core/teos.py
@@ -779,7 +779,7 @@ def node_probe():
     pid = None
     for i in range(0, 5):
         pids = [p.info for p in psutil.process_iter(attrs=["pid", "name"]) \
-                                        if NODEOS in p.info["name"]]
+                                        if p.info["name"] and NODEOS in p.info["name"]]
         if pids and pids[0]["name"] == NODEOS:
             pid = pids[0]["pid"]
             break


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfix


* **What is the current behavior?** (You can also link to an open issue here)

On my MacBook I get:
``TypeError: argument of type 'NoneType' is not iterable```
when `get_pid` is called.

It seems I have at least one process running whose `p.info["name"]` gets reported as `None`. 


* **What is the new behavior (if this is a feature change)?**

Adding a simple check to pass this case.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


* **Other information**:


